### PR TITLE
fix: app-region height

### DIFF
--- a/src/components/AppRegion/AppRegion.scss
+++ b/src/components/AppRegion/AppRegion.scss
@@ -1,6 +1,6 @@
 .app-region {
   @include absolute(0, null, 0);
-  @include dimen(100%, var(--header-height));
+  width: 100%;
 
   .simple-title-bar {
     @include sq-dimen(100%);


### PR DESCRIPTION
the app-region element was extending over the task list dropdown and preventing it from receive click events